### PR TITLE
Add Terraform infrastructure scaffolding

### DIFF
--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -1,0 +1,77 @@
+resource "aws_ecs_cluster" "ahtr_cluster" {
+  name = "ahtr-cluster"
+}
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "ahtr-ecs-exec"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Action = "sts:AssumeRole",
+      Effect = "Allow",
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_exec_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_security_group" "ecs_sg" {
+  name        = "ahtr-ecs-sg"
+  description = "Allow HTTP access"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_task_definition" "ahtr" {
+  family                   = "ahtr-task"
+  cpu                      = "256"
+  memory                   = "512"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "ahtr-app",
+      image = var.container_image,
+      portMappings = [
+        {
+          containerPort = 80,
+          hostPort      = 80,
+          protocol      = "tcp"
+        }
+      ]
+    }
+  ])
+}
+
+resource "aws_ecs_service" "ahtr_service" {
+  name            = "ahtr-service"
+  cluster         = aws_ecs_cluster.ahtr_cluster.id
+  task_definition = aws_ecs_task_definition.ahtr.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnets
+    security_groups = [aws_security_group.ecs_sg.id]
+    assign_public_ip = true
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = var.state_bucket
+    key    = "terraform.tfstate"
+    region = var.region
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -32,3 +32,8 @@ resource "aws_security_group" "db_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+resource "aws_db_subnet_group" "ahtr_subnet_group" {
+  name       = "ahtr-db-subnets"
+  subnet_ids = var.private_subnets
+}

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -1,0 +1,33 @@
+resource "aws_s3_bucket" "app_bucket" {
+  bucket = var.bucket_name
+  acl    = "private"
+}
+
+resource "aws_iam_role" "app_role" {
+  name = "ahtr-app-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = { Service = "ecs-tasks.amazonaws.com" },
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_policy" "app_s3_policy" {
+  name   = "ahtr-app-s3"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = ["s3:*"],
+      Resource = [aws_s3_bucket.app_bucket.arn, "${aws_s3_bucket.app_bucket.arn}/*"]
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "app_policy_attach" {
+  role       = aws_iam_role.app_role.name
+  policy_arn = aws_iam_policy.app_s3_policy.arn
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,45 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "state_bucket" {
+  description = "S3 bucket for Terraform state"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "S3 bucket for application data"
+  type        = string
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+}
+
+variable "db_user" {
+  description = "Database username"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Database password"
+  type        = string
+  sensitive   = true
+}
+
+variable "vpc_id" {
+  description = "VPC id for resources"
+  type        = string
+}
+
+variable "private_subnets" {
+  description = "List of private subnet IDs"
+  type        = list(string)
+}
+
+variable "container_image" {
+  description = "Docker image for ECS service"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- configure AWS provider and remote state backend
- scaffold ECS Fargate cluster and service
- add S3 bucket and IAM roles
- declare Terraform variables
- expand RDS module with subnet group

## Testing
- `terraform init -backend=false` *(fails: could not access registry)*
- `terraform validate` *(fails: missing provider due to init failure)*

------
https://chatgpt.com/codex/tasks/task_b_6872f6ef41b88331b6458c5d43364c47